### PR TITLE
Now using EmbeddedEventStore for integration tests

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -53,6 +53,8 @@ Then, add the following settings to the `App.config` file of the root project:
 </configuration>
 ```
 
+It is also possible to pass in a ready-made instance of `IEventStoreConnection` in the constructor of the `EventStoreFeature`. This has been made available to facilitate the integration test suite that now uses the EventStore [Embedded Client](http://docs.geteventstore.com/dotnet-api/4.0.0/embedded-client/) and which passes in an instance of `EmbeddedEventStoreConnection`. 
+
 **Please note** that this sample assumes that:
 
 - EventStore is running on your **local host**. **1113** is the TCP port at which you can listen for events and **2113** is the HTTP port. These are the default ports that EventStore uses.

--- a/src/ServiceStack.EventStore/Exceptions/AggregateDeletedException.cs
+++ b/src/ServiceStack.EventStore/Exceptions/AggregateDeletedException.cs
@@ -8,6 +8,7 @@ namespace ServiceStack.EventStore.Exceptions
     /// <summary>
     /// An exception thrown when a requested (aggregate) stream has been deleted.
     /// </summary>
+    [Serializable]
     public class AggregateDeletedException : Exception
     {
         public readonly Guid Id;

--- a/src/ServiceStack.EventStore/Exceptions/AggregateNotFoundException.cs
+++ b/src/ServiceStack.EventStore/Exceptions/AggregateNotFoundException.cs
@@ -8,6 +8,7 @@ namespace ServiceStack.EventStore.Exceptions
     /// <summary>
     /// An exception thrown when a requested (aggregate) stream can't be found.
     /// </summary>
+    [Serializable]
     public class AggregateNotFoundException : Exception
     {
         public readonly Guid Id;

--- a/src/ServiceStack.EventStore/Exceptions/AggregateVersionException.cs
+++ b/src/ServiceStack.EventStore/Exceptions/AggregateVersionException.cs
@@ -9,6 +9,7 @@ namespace ServiceStack.EventStore.Exceptions
     /// An exception thrown when trying persist new events to an 
     /// (aggregate) stream but there have been other changes in the meantime.
     /// </summary>
+    [Serializable]
     public class AggregateVersionException : Exception
     {
         public readonly Guid Id;

--- a/src/ServiceStack.EventStore/Exceptions/EventNotFoundException.cs
+++ b/src/ServiceStack.EventStore/Exceptions/EventNotFoundException.cs
@@ -5,6 +5,7 @@ namespace ServiceStack.EventStore.Exceptions
 {
     using System;
 
+    [Serializable]
     public class EventNotFoundException: Exception
     {
         private readonly string stream;

--- a/src/ServiceStack.EventStore/Exceptions/EventNotFoundException.cs
+++ b/src/ServiceStack.EventStore/Exceptions/EventNotFoundException.cs
@@ -8,13 +8,13 @@ namespace ServiceStack.EventStore.Exceptions
     [Serializable]
     public class EventNotFoundException: Exception
     {
-        private readonly string stream;
-        private readonly int position;
+        public readonly string StreamId;
+        public readonly int Position;
 
-        public EventNotFoundException(string stream, int position)
+        public EventNotFoundException(string streamId, int position)
         {
-            this.stream = stream;
-            this.position = position;
+            StreamId = streamId;
+            Position = position;
         }
     }
 }

--- a/src/ServiceStack.EventStore/Main/EventStoreFeature.cs
+++ b/src/ServiceStack.EventStore/Main/EventStoreFeature.cs
@@ -52,8 +52,8 @@ namespace ServiceStack.EventStore.Main
             log = LogManager.GetLogger(GetType());
         }
 
-        public EventStoreFeature(ClusterVNode clusterNode, SubscriptionSettings subscriptionSettings, params Assembly[] assembliesWithEvents)
-            : this(subscriptionSettings, assembliesWithEvents)
+        public EventStoreFeature(ClusterVNode clusterNode, params Assembly[] assembliesWithEvents)
+            : this(new SubscriptionSettings(), assembliesWithEvents)
         {
             this.clusterNode = clusterNode;
         }

--- a/src/ServiceStack.EventStore/ServiceStack.EventStore.csproj
+++ b/src/ServiceStack.EventStore/ServiceStack.EventStore.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -39,6 +41,10 @@
   <ItemGroup>
     <Reference Include="EventStore.ClientAPI, Version=3.9.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EventStore.Client.3.9.4\lib\net40\EventStore.ClientAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EventStore.ClientAPI.Embedded, Version=3.9.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EventStore.Client.Embedded.3.9.4\lib\net40\EventStore.ClientAPI.Embedded.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
@@ -148,6 +154,13 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets" Condition="Exists('..\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ServiceStack.EventStore/ServiceStack.EventStore.csproj
+++ b/src/ServiceStack.EventStore/ServiceStack.EventStore.csproj
@@ -43,10 +43,6 @@
       <HintPath>..\packages\EventStore.Client.3.9.4\lib\net40\EventStore.ClientAPI.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EventStore.ClientAPI.Embedded, Version=3.9.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EventStore.Client.Embedded.3.9.4\lib\net40\EventStore.ClientAPI.Embedded.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Polly, Version=4.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Polly.4.1.2\lib\net45\Polly.dll</HintPath>
@@ -154,13 +150,6 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets" Condition="Exists('..\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ServiceStack.EventStore/packages.config
+++ b/src/ServiceStack.EventStore/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EventStore.Client" version="3.9.4" targetFramework="net452" />
-  <package id="EventStore.Client.Embedded" version="3.9.4" targetFramework="net452" />
   <package id="Polly" version="4.1.2" targetFramework="net452" />
   <package id="ServiceStack" version="4.0.54" targetFramework="net452" />
   <package id="ServiceStack.Client" version="4.0.54" targetFramework="net452" />

--- a/src/ServiceStack.EventStore/packages.config
+++ b/src/ServiceStack.EventStore/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EventStore.Client" version="3.9.4" targetFramework="net452" />
+  <package id="EventStore.Client.Embedded" version="3.9.4" targetFramework="net452" />
   <package id="Polly" version="4.1.2" targetFramework="net452" />
   <package id="ServiceStack" version="4.0.54" targetFramework="net452" />
   <package id="ServiceStack.Client" version="4.0.54" targetFramework="net452" />

--- a/test/ServiceStack.EventStore.IntegrationTests/ServiceStack.EventStore.IntegrationTests.csproj
+++ b/test/ServiceStack.EventStore.IntegrationTests/ServiceStack.EventStore.IntegrationTests.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>ServiceStack.EventStore.IntegrationTests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,6 +34,10 @@
   <ItemGroup>
     <Reference Include="EventStore.ClientAPI, Version=3.9.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\src\packages\EventStore.Client.3.9.4\lib\net40\EventStore.ClientAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EventStore.ClientAPI.Embedded, Version=3.9.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\EventStore.Client.Embedded.3.9.4\lib\net40\EventStore.ClientAPI.Embedded.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FluentAssertions, Version=4.3.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
@@ -139,6 +145,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\src\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets" Condition="Exists('..\..\src\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\src\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\src\packages\EventStore.Client.Embedded.3.9.4\build\EventStore.Client.Embedded.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/ServiceStack.EventStore.IntegrationTests/TestAppHost.cs
+++ b/test/ServiceStack.EventStore.IntegrationTests/TestAppHost.cs
@@ -22,15 +22,9 @@ namespace ServiceStack.EventStore.IntegrationTests
 
         public override void Configure(Container container)
         {
-            var settings = new SubscriptionSettings()
-                .SubscribeToStreams(streams =>
-                {
-                    streams.Add(new ReadModelSubscription()
-                        .SetRetryPolicy(1.Seconds(), 3.Seconds())
-                        .WithStorage(new ReadModelStorage(StorageType.Redis, "localhost:6379")));
-                });
 
             LogManager.LogFactory = new ConsoleLogFactory();
+
             var nodeBuilder = EmbeddedVNodeBuilder.AsSingleNode()
                            .OnDefaultEndpoints()
                            .RunInMemory();
@@ -39,7 +33,7 @@ namespace ServiceStack.EventStore.IntegrationTests
 
 
             Plugins.Add(new MetadataFeature());
-            Plugins.Add(new EventStoreFeature(node, settings, typeof(TestAppHost).Assembly));
+            Plugins.Add(new EventStoreFeature(node, typeof(TestAppHost).Assembly));
         }
     }
 }

--- a/test/ServiceStack.EventStore.IntegrationTests/TestAppHost.cs
+++ b/test/ServiceStack.EventStore.IntegrationTests/TestAppHost.cs
@@ -6,6 +6,7 @@ namespace ServiceStack.EventStore.IntegrationTests
 {
     using FluentAssertions;
     using Funq;
+    using global::EventStore.ClientAPI.Embedded;
     using Logging;
     using Main;
     using Projections;
@@ -30,9 +31,15 @@ namespace ServiceStack.EventStore.IntegrationTests
                 });
 
             LogManager.LogFactory = new ConsoleLogFactory();
+            var nodeBuilder = EmbeddedVNodeBuilder.AsSingleNode()
+                           .OnDefaultEndpoints()
+                           .RunInMemory();
+            var node = nodeBuilder.Build();
+            node.StartAndWaitUntilReady().Wait();
+
 
             Plugins.Add(new MetadataFeature());
-            Plugins.Add(new EventStoreFeature(settings, typeof(TestAppHost).Assembly));
+            Plugins.Add(new EventStoreFeature(node, settings, typeof(TestAppHost).Assembly));
         }
     }
 }

--- a/test/ServiceStack.EventStore.IntegrationTests/TestAppHost.cs
+++ b/test/ServiceStack.EventStore.IntegrationTests/TestAppHost.cs
@@ -25,15 +25,17 @@ namespace ServiceStack.EventStore.IntegrationTests
 
             LogManager.LogFactory = new ConsoleLogFactory();
 
-            var nodeBuilder = EmbeddedVNodeBuilder.AsSingleNode()
-                           .OnDefaultEndpoints()
-                           .RunInMemory();
+            var nodeBuilder = EmbeddedVNodeBuilder
+                                .AsSingleNode()
+                                .OnDefaultEndpoints()
+                                .RunInMemory();
             var node = nodeBuilder.Build();
-            node.StartAndWaitUntilReady().Wait();
 
+            node.StartAndWaitUntilReady().Wait();
+            var testConnection = EmbeddedEventStoreConnection.Create(node);
 
             Plugins.Add(new MetadataFeature());
-            Plugins.Add(new EventStoreFeature(node, typeof(TestAppHost).Assembly));
+            Plugins.Add(new EventStoreFeature(testConnection, typeof(TestAppHost).Assembly));
         }
     }
 }

--- a/test/ServiceStack.EventStore.IntegrationTests/TestClasses/ProjectionTests.cs
+++ b/test/ServiceStack.EventStore.IntegrationTests/TestClasses/ProjectionTests.cs
@@ -21,14 +21,5 @@ namespace ServiceStack.EventStore.IntegrationTests.TestClasses
             eventStore = fixture.AppHost.Container.Resolve<IEventStoreRepository>();
             testOutput = output;
         }
-
-        [Fact]
-
-        public async Task CanPopulateViewModel()
-        {
-            //var builder = new ReadModelBuilder<PurchaseOrderViewModel>();
-
-        }
-
     }
 }

--- a/test/ServiceStack.EventStore.IntegrationTests/TestClasses/ServiceStackHostFixture.cs
+++ b/test/ServiceStack.EventStore.IntegrationTests/TestClasses/ServiceStackHostFixture.cs
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 namespace ServiceStack.EventStore.IntegrationTests.TestClasses
 {
+    using global::EventStore.ClientAPI.Embedded;
+
     public class ServiceStackHostFixture
     {
         private const string ListeningOn = "http://localhost:8088/";

--- a/test/ServiceStack.EventStore.IntegrationTests/packages.config
+++ b/test/ServiceStack.EventStore.IntegrationTests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EventStore.Client" version="3.9.4" targetFramework="net452" />
+  <package id="EventStore.Client.Embedded" version="3.9.4" targetFramework="net452" />
   <package id="FluentAssertions" version="4.3.2" targetFramework="net452" />
   <package id="ServiceStack" version="4.0.54" targetFramework="net452" />
   <package id="ServiceStack.Client" version="4.0.54" targetFramework="net452" />


### PR DESCRIPTION
This resolves #6. 

The integration tests no longer need to be run against a live instance
of EventStore. Instead an embedded instance of EventStore is fired up
and executed against.